### PR TITLE
Add some new strippers

### DIFF
--- a/stripper/maps/mg_airmap_run_v2.cfg
+++ b/stripper/maps/mg_airmap_run_v2.cfg
@@ -1,0 +1,207 @@
+// Changes:
+//	- Hopefully fix VCollide lag
+//	- Make these doors not bhop blocks so one isn't messed up by players in front of them
+//	- Make alternative paths not get disabled
+//	- Remove grenade effects and make them only aesthetics
+//	- Fix start push not syncing up with steam
+//	- Remove the spawn killer
+
+// Hopefully fix VCollide lag
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+	}
+	replace:
+	{
+		"solid" "0"
+	}
+}
+
+// Make these doors not bhop blocks so one isn't messed up by players in front of them
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"spawnflags" "1024"
+	}
+	replace:
+	{
+		"spawnflags" "0"
+	}
+}
+
+// Make alternative paths always enabled
+modify:
+{
+	match:
+	{
+		"classname" "func_wall_toggle"
+	}
+	replace:
+	{
+		"spawnflags" "0"
+	}
+}
+
+filter:
+{
+	"classname" "func_button"
+	"hammerid" "2067475"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_hegrenade"
+		"targetname" "greubonus1"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "bim1Toggle0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_hegrenade"
+		"targetname" "greubonus2"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "bnus33Toggle0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_hegrenade"
+		"targetname" "greubonus3"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "bnus33Toggle0-1"
+	}
+}
+
+filter:
+{
+	"classname" "func_button"
+	"hammerid" "2162310"
+}
+
+filter:
+{
+	"classname" "func_button"
+	"hammerid" "2276112"
+}
+
+// Remove grenade effects and make them only aesthetics
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "speed"
+}
+
+filter:
+{
+	"classname" "trigger_hurt"
+	"damage" "-15"
+}
+
+// Fix start push not syncing up with steam
+modify:
+{
+	match:
+	{
+		"classname" "trigger_push"
+		"targetname" "p1"
+	}
+	replace:
+	{
+		"StartDisabled" "0"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_push"
+		"targetname" "p4"
+	}
+	replace:
+	{
+		"StartDisabled" "0"
+	}
+}
+
+// Remove the spawn killer
+filter:
+{
+	"classname" "trigger_teleport"
+	"targetname" "dpzxnkill"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"hammerid" "269336"
+	}
+	delete:
+	{
+		"OnPass" "dpzxnkillEnable0-1"
+	}
+}
+
+filter:
+{
+	"classname" "logic_auto"
+	"hammerid" "2605363"
+}
+
+filter:
+{
+	"classname" "func_button"
+	"targetname" "loker"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"hammerid" "2257542"
+	}
+	delete:
+	{
+		"OnStartTouch" "lokerPress0-1"
+	}
+}
+
+filter:
+{
+	"classname" "info_particle_system"
+	"targetname" "aieu"
+}
+
+filter:
+{
+	"classname" "point_tesla"
+	"targetname" "tesla2"
+}
+
+filter:
+{
+	"classname" "func_tracktrain"
+	"targetname" "meteorgeekso"
+}

--- a/stripper/maps/mg_cartoon_course_v3_1_hdr.cfg
+++ b/stripper/maps/mg_cartoon_course_v3_1_hdr.cfg
@@ -1,0 +1,125 @@
+//Changes:
+//	- Removes breakables that only first person would have to break
+//	- Remove the spawn killer
+
+// Removes breakables that only first person would have to break
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "349600"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "349608"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "347955"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "347968"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "347978"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "337640"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "268134"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "259118"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "259736"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "256188"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "256205"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "119347"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "100503"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "93024"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "90352"
+}
+
+filter:
+{
+	"classname" "func_breakable"
+	"hammerid" "30921"
+}
+
+// Remove the spawn killer
+filter:
+{
+	"classname" "trigger_hurt"
+	"targetname" "Spawn trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "435051"
+	}
+	delete:
+	{
+		"OnMapSpawn" "Spawn triggerEnable65-1"
+		"OnMapSpawn" "CommandCommandsay AFK killer activates in 10 seconds55-1"
+		"OnMapSpawn" "CommandCommandsay AFK killer has been activated!65-1"
+		"OnMapSpawn" "CommandCommandmp_respawn_on_death_t 060-1"
+		"OnMapSpawn" "CommandCommandsay Respawn enabled!0-1"
+		"OnMapSpawn" "CommandCommandsay Respawn disabled!60-1"
+	}
+}

--- a/stripper/maps/mg_wipeout_course_v1b.cfg
+++ b/stripper/maps/mg_wipeout_course_v1b.cfg
@@ -1,0 +1,239 @@
+//Changes:
+//	- Make spawnpoints angle the way the map starts
+//	- Block some skips
+//	- Block some spots players can get out of the map
+//	- Remove a seemingly random trigger_hurt
+//	- Remove the spawn killer
+
+// Block some skips
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "1080 360 464"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*57"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "1080 296 464"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*57"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "832 360 464"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*57"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "832 296 464"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*57"
+}
+
+// Block some spots players can get out of the map
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"hammerid" "73199"
+	}
+	replace:
+	{
+		"origin" "3930 1730 26.5"
+	}
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "3954 1730 154.5"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*1"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "-306.01 18 210.5"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*1"
+	"angles" "0 90 0"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "372 1218 210.5"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*15"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "5294 -1782 152.2"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*1"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "5294 -1766 72.2"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*1"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "4106 -1782 232.2"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*1"
+}
+
+// Remove a seemingly random trigger_hurt
+filter:
+{
+	"classname" "trigger_hurt"
+	"origin" "5200 -304 166.5"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "4496 -304 166.5"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*12"
+	"angles" "0 90 0"
+}
+
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "99999"
+	"damagecap" "99999"
+	"damagemodel" "0"
+	"damagetype" "0"
+	"nodmgforce" "0"
+	"origin" "5200 -1008 166.5"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"model" "*12"
+} 
+
+// Make spawnpoints angle the way the map starts
+modify:
+{
+	match:
+	{
+		"classname" "info_player_terrorist"
+	}
+	replace:
+	{
+		"angles" "0 90 0"
+	}
+}
+
+// Remove the spawn killer
+filter:
+{
+	"classname" "trigger_hurt"
+	"targetname" "spawnkiller"
+}
+
+filter:
+{
+	"classname" "logic_timer"
+	"targetname" "hurttime"
+}
+
+// Remove fall damage
+add:
+{
+	"classname" "logic_auto"
+	"origin" "216 -1576 657"
+	"OnMapSpawn" "console,Command,sv_falldamage_scale 0,0,-1"
+}
+
+add:
+{
+	"classname" "point_servercommand"
+	"targetname" "console"
+	"origin" "216 -1576 657"
+}


### PR DESCRIPTION
Cartoon Course:
- Removes breakables that only first person would have to break
- Remove the spawn killer

Wipeout Course:
- Make spawnpoints angle the way the map starts
- Block some skips
- Block some spots players can get out of the map
- Remove a seemingly random trigger_hurt
- Remove the spawn killer

Airmap Run v2:
- Hopefully fix VCollide lag on ending trees
- Make these doors not bhop blocks so one isn't messed up by players in front of them
- Make alternative paths not get disabled
- Remove grenade effects and make them only aesthetics
- Fix start push not syncing up with steam
- Remove the spawn killer